### PR TITLE
Link-fragments-in-html-conversions

### DIFF
--- a/.github/workflows/respec.yaml
+++ b/.github/workflows/respec.yaml
@@ -33,7 +33,7 @@ jobs:
     - uses: actions/checkout@v2 # checkout gh-pages branch
       with:
         token: ${{ secrets.OAS_REPO_TOKEN }}
-        repository: OAI/OpenAPI-Specification  
+        repository: frankkilcommins/OpenAPI-Specification  
         ref: gh-pages
         path: deploy
 

--- a/.github/workflows/respec.yaml
+++ b/.github/workflows/respec.yaml
@@ -33,7 +33,7 @@ jobs:
     - uses: actions/checkout@v2 # checkout gh-pages branch
       with:
         token: ${{ secrets.OAS_REPO_TOKEN }}
-        repository: frankkilcommins/OpenAPI-Specification  
+        repository: OAI/OpenAPI-Specification  
         ref: gh-pages
         path: deploy
 

--- a/scripts/md2html/md2html.js
+++ b/scripts/md2html/md2html.js
@@ -267,8 +267,17 @@ for (let l in lines) {
             line = line.replace('https://xml2rfc.ietf.org/public/rfc/html/rfc','https://tools.ietf.org/html/rfc');
             line = line.replace('.html','');
         }
-        line = line.replace(/\]\]\(https:\/\/tools.ietf.org\/html\/rfc[0-9]{1,5}\/?(\#.*?)?\)/g,function(match,group1){
-            return ']]';
+
+        //handle url fragments in RFC links and construct section titles links as well as RFC links
+        line = line.replace(/\]\]\(https:\/\/tools.ietf.org\/html\/rfc([0-9]{1,5})(\/?\#.*?)?\)/g, function(match, rfcNumber, fragment) {
+            if (fragment) {
+                // Extract section title from the fragment
+                let sectionTitle = fragment.replace('#', '').replace(/-/g, ' ');
+                sectionTitle = sectionTitle.charAt(0).toUpperCase() + sectionTitle.slice(1); // Capitalize the first letter
+                return `]] [${sectionTitle}](https://tools.ietf.org/html/rfc${rfcNumber}${fragment})`;
+            } else {
+                return ']]';
+            }
         });
     }
 

--- a/versions/1.0.0.md
+++ b/versions/1.0.0.md
@@ -744,7 +744,7 @@ This object MAY be extended with [Specification Extensions](#specification-exten
     }
 ```
 
- **JSON Object Example**
+**JSON Object Example**
 ```yaml
   contentType: application/json
   payload: 
@@ -760,7 +760,7 @@ This object MAY be extended with [Specification Extensions](#specification-exten
 ```yaml
   contentType: application/json
   payload: $inputs.petOrderRequest
- ```
+```
 
 **XML Templated Example**
  ```yaml

--- a/versions/1.0.0.md
+++ b/versions/1.0.0.md
@@ -692,7 +692,7 @@ An object used to describe the type and version of an expression used within a [
 
 Defining this object gives the ability to utilize tooling compatible with older versions of either JSONPath or XPath.
 
- ##### Fixed Fields
+##### Fixed Fields
 Field Name | Type | Description
 ---|:---:|---
 <a name="criterionExpressionType"></a>type | `string` | **REQUIRED**. The type of condition to be applied. The options allowed are `jsonpath` or `xpath`. 
@@ -728,8 +728,9 @@ Field Name | Type | Description
 This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### RequestBody Object Example
- **JSON Templated Example**
- ```yaml
+
+**JSON Templated Example**
+```yaml
   contentType: application/json
   payload: |
     {
@@ -741,10 +742,10 @@ This object MAY be extended with [Specification Extensions](#specification-exten
         "complete": false
       }
     }
- ```
+```
 
-  **JSON Object Example**
- ```yaml
+ **JSON Object Example**
+```yaml
   contentType: application/json
   payload: 
     petOrder:
@@ -753,15 +754,15 @@ This object MAY be extended with [Specification Extensions](#specification-exten
       quantity: $inputs.quantity
       status: placed
       complete: false
- ```
+```
 
-  **Complete Runtime Expression**
- ```yaml
+**Complete Runtime Expression**
+```yaml
   contentType: application/json
   payload: $inputs.petOrderRequest
  ```
 
-  **XML Templated Example**
+**XML Templated Example**
  ```yaml
   contentType: application/xml
   payload: |
@@ -772,10 +773,10 @@ This object MAY be extended with [Specification Extensions](#specification-exten
       <status>placed</status>
       <complete>false</complete>
     </petOrder>
- ```
+```
 
 **Form Data Example**
- ```yaml
+```yaml
   contentType: application/x-www-form-urlencoded
   payload: 
     client_id: $inputs.clientId
@@ -784,10 +785,10 @@ This object MAY be extended with [Specification Extensions](#specification-exten
     client_secret: $inputs.clientSecret
     code: $steps.browser-authorize.outputs.code
     scope: $inputs.scope  
- ```
+```
 
 **Form Data String Example**
- ```yaml
+```yaml
   contentType: application/x-www-form-urlencoded
   payload: "client_id={$inputs.clientId}&grant_type={$inputs.grantType}&redirect_uri={$inputs.redirectUri}&client_secret={$inputs.clientSecret}&code{$steps.browser-authorize.outputs.code}&scope=$inputs.scope}"
 ```
@@ -807,14 +808,14 @@ This object MAY be extended with [Specification Extensions](#specification-exten
 
 **Runtime Expression Example**
 ```yaml
-    target: /petId
-    value: $inputs.pet_id
+  target: /petId
+  value: $inputs.pet_id
 ```
 
 **Literal Example**
 ```yaml
-    target: /quantity
-    value: 10
+  target: /quantity
+  value: 10
 ```
 
 
@@ -843,7 +844,7 @@ The runtime expression is defined by the following [ABNF](https://tools.ietf.org
         "^" / "_" / "`" / "|" / "~" / DIGIT / ALPHA
 ```
 
-##### Examples
+#### Examples
 
 Source Location | example expression  | notes
 ---|:---|:---|

--- a/versions/1.0.0.md
+++ b/versions/1.0.0.md
@@ -763,7 +763,7 @@ This object MAY be extended with [Specification Extensions](#specification-exten
 ```
 
 **XML Templated Example**
- ```yaml
+```yaml
   contentType: application/xml
   payload: |
     <petOrder>
@@ -785,7 +785,7 @@ This object MAY be extended with [Specification Extensions](#specification-exten
     client_secret: $inputs.clientSecret
     code: $steps.browser-authorize.outputs.code
     scope: $inputs.scope  
-```
+``` 
 
 **Form Data String Example**
 ```yaml


### PR DESCRIPTION
Address ToC issue in the HTML ReSpec as well as an improved mechanism for creating RFC links which contain sections (e.g. fragments).

fixes: #194
refs: https://github.com/OAI/OpenAPI-Specification/issues/3863

Improved RFC section linking will look like the following (RFC bib link + additional section specific link):
![image](https://github.com/OAI/Arazzo-Specification/assets/15875424/6d42c269-f51a-4a53-af9d-779a87ce9c95)
