### PR TITLE
Wrap long lines in code blocks that do not wrap when rendered

### DIFF
--- a/versions/1.0.0.md
+++ b/versions/1.0.0.md
@@ -120,9 +120,12 @@ This object MAY be extended with [Specification Extensions](#specification-exten
 arazzo: 1.0.0
 info:
   title: A pet purchasing workflow
-  summary: This Arazzo Description showcases the workflow for how to purchase a pet through a sequence of API calls
+  summary: |
+    This Arazzo Description showcases the workflow for how to purchase a pet
+    through a sequence of API calls
   description: |
-      This Arazzo Description walks you through the workflow and steps of `searching` for, `selecting`, and `purchasing` an available pet.
+      This Arazzo Description walks you through the workflow and steps of
+      `searching` for, `selecting`, and `purchasing` an available pet.
   version: 1.0.1
 sourceDescriptions:
 - name: petStoreDescription
@@ -145,7 +148,9 @@ workflows:
     description: This step demonstrates the user login step
     operationId: loginUser
     parameters:
-      # parameters to inject into the loginUser operation (parameter name must be resolvable at the referenced operation and the value is determined using {expression} syntax)
+      # parameters to inject into the loginUser operation (parameter name must
+      # be resolvable at the referenced operation and the value is determined
+      # using {expression} syntax)
       - name: username
         in: query
         value: $inputs.username
@@ -202,7 +207,8 @@ This object MAY be extended with [Specification Extensions](#specification-exten
 title: A pet purchasing workflow
 summary: This workflow showcases how to purchase a pet through a sequence of API calls
 description: |
-    This workflow walks you through the steps of searching for, selecting, and purchasing an available pet.
+    This workflow walks you through the steps of searching for, selecting, and
+    purchasing an available pet.
 version: 1.0.1
 ```
 
@@ -271,7 +277,9 @@ steps:
     description: This step demonstrates the user login step
     operationId: loginUser
     parameters:
-      # parameters to inject into the loginUser operation (parameter name must be resolvable at the referenced operation and the value is determined using {expression} syntax)
+      # parameters to inject into the loginUser operation (parameter name must
+      # be resolvable at the referenced operation and the value is determined
+      # using {expression} syntax)
       - name: username
         in: query
         value: $inputs.username
@@ -320,7 +328,9 @@ stepId: loginStep
 description: This step demonstrates the user login step
 operationId: loginUser
 parameters:
-    # parameters to inject into the loginUser operation (parameter name must be resolvable at the referenced operation and the value is determined using {expression} syntax)
+    # parameters to inject into the loginUser operation (parameter name must
+    # be resolvable at the referenced operation and the value is determined
+    # using {expression} syntax)
     - name: username
       in: query
       value: $inputs.username
@@ -344,7 +354,9 @@ steps:
     description: This step demonstrates the user login step
     operationId: loginUser
     parameters:
-        # parameters to inject into the loginUser operation (parameter name must be resolvable at the referenced operation and the value is determined using {expression} syntax)
+        # parameters to inject into the loginUser operation (parameter name must
+        # be resolvable at the referenced operation and the value is determined
+        # using {expression} syntax)
       - name: username
         in: query
         value: $inputs.username


### PR DESCRIPTION
In a number of the code blocks you have to scroll right to read long lines. This breaks long lines at 80 columns - not all of them, as URIs, runtime expressions, etc are not wrapped, but where possible.