### PR TITLE
Move misplaced parenthesis in Step Object description

### DIFF
--- a/versions/1.0.0.md
+++ b/versions/1.0.0.md
@@ -291,7 +291,7 @@ outputs:
 
 #### Step Object
 
-Describes a single workflow step which MAY be a call to an API operation ([OpenAPI Operation Object](https://spec.openapis.org/oas/latest.html#operation-object) or another [Workflow Object](#workflow-object)).
+Describes a single workflow step which MAY be a call to an API operation ([OpenAPI Operation Object](https://spec.openapis.org/oas/latest.html#operation-object)) or another [Workflow Object](#workflow-object).
 
 ##### Fixed Fields
 


### PR DESCRIPTION
This PR fixes https://github.com/OAI/Arazzo-Specification/issues/247 by moving a misplaced parenthesis.