### PR TITLE
adding template for Arazzo mettings with code-of-conduct

### DIFF
--- a/.github/templates/agenda.md
+++ b/.github/templates/agenda.md
@@ -1,6 +1,6 @@
 ## Bi-Weekly meetings happen on Wednesdays at 5PM GMT
 
-This agenda gives visibility into discussion topics for the weekly Technical Developer Community (TDC) meetings. Sharing agenda items in advance allows people to plan to attend meetings where they have an interest in specific topics. 
+This agenda gives visibility into discussion topics for the bi-weekly Arazzo Specification Technical Developer Community (TDC) meetings. Sharing agenda items in advance allows people to plan to attend meetings where they have an interest in specific topics. 
 
 Whether attending or not, **anyone can comment on this issue prior to the meeting to suggest topics or to add comments on planned topics or proposals**.
 

--- a/.github/templates/agenda.md
+++ b/.github/templates/agenda.md
@@ -25,11 +25,10 @@ Meetings take place over Zoom: [https://zoom.us/j/91426197903](https://zoom.us/j
 
 | Topic | Owner | Decision/NextStep |
 |-|-|-|
-Intros and governance meta-topics (5 mins) | TDC | |
-Reports from Special Interest Groups (5 mins) | SIG members | |
-Any other business (add comments below to suggest topics) | TDC | |
-[Approved spec PRs](https://github.com/OAI/Arazzo-Specification/pulls?q=is%3Apr+is%3Aopen+review%3Aapproved) | @OAI/tsc | |
-[Active Projects](https://github.com/OAI/Arazzo-Specification/projects?query=is%3Aopen) | @OAI/openapi-maintainers | |
-[New issues needing attention](https://github.com/search?q=repo%3Aoai%2Farazzo-specification+is%3Aissue+comments%3A0+no%3Alabel+is%3Aopen) | @OAI/triage  | |
+Intros and governance meta-topics (5 mins) | TDC / Arazzo maintainers | |
+Any other business (add comments below to suggest topics) | TDC / Arazzo maintainers | |
+[Approved spec PRs](https://github.com/OAI/Arazzo-Specification/pulls?q=is%3Apr+is%3Aopen+review%3Aapproved) | Arazzo maintainers| |
+[Active Projects](https://github.com/OAI/Arazzo-Specification/projects?query=is%3Aopen) | Arazzo maintainers | |
+[New issues needing attention](https://github.com/search?q=repo%3Aoai%2Farazzo-specification+is%3Aissue+comments%3A0+no%3Alabel+is%3Aopen) | Arazzo maintainers  | |
 
 /cc [@OAI/tsc](https://github.com/orgs/OAI/teams/tsc) please suggest items for inclusion.

--- a/.github/templates/agenda.md
+++ b/.github/templates/agenda.md
@@ -9,7 +9,6 @@ Meetings take place over Zoom: [https://zoom.us/j/91426197903](https://zoom.us/j
 ### Accessibility & Etiquette
 * Participants must abide by our [Code-of-Conduct](https://github.com/OAI/OpenAPI-Specification/blob/main/CODE_OF_CONDUCT.md#code-of-conduct).
 
-* [Meetings are recorded](https://openapi.meetrecord.com/redoc#tag/Recordings/operation/get_recordings_api_v1_recordings_get) for future reference, and for those who are not able to attend in-person.
 
 * We invite you to feel comfortable to challenge any language or behaviour that is harmful or not inclusive during this meeting.
 

--- a/.github/templates/agenda.md
+++ b/.github/templates/agenda.md
@@ -1,0 +1,36 @@
+## Weekly meetings happen on Thursdays at 9am - 10am Pacific
+
+This agenda gives visibility into discussion topics for the weekly Technical Developer Community (TDC) meetings. Sharing agenda items in advance allows people to plan to attend meetings where they have an interest in specific topics. 
+
+Whether attending or not, **anyone can comment on this issue prior to the meeting to suggest topics or to add comments on planned topics or proposals**.
+
+Meetings take place over Zoom: [https://zoom.us/j/91426197903](https://zoom.us/j/91426197903?pwd=cjNGcjgzWmRqZ1YyRW9PM3FFNFVFUT09), dial-in passcode: 763054
+
+### Accessibility & Etiquette
+* Participants must abide by our [Code-of-Conduct](https://github.com/OAI/OpenAPI-Specification/blob/main/CODE_OF_CONDUCT.md#code-of-conduct).
+
+* [Meetings are recorded](https://openapi.meetrecord.com/redoc#tag/Recordings/operation/get_recordings_api_v1_recordings_get) for future reference, and for those who are not able to attend in-person.
+
+* We invite you to feel comfortable to challenge any language or behaviour that is harmful or not inclusive during this meeting.
+
+* We look forward to your participation, but please consider these acts of etiquette:
+  * Remain on mute when not speaking to prevent interruptions.
+  * Blur your background to reduce visual distractions.
+  * Use the Zoom meeting "Raise Hand" feature to notify the group when you wish to speak.
+
+| Blur My Background | Raise Hand |
+|-|-|
+| <img width="323" alt="Screenshot of Zoom UI showing the 'Stop Video' and 'Blur My Background' control" src="https://github.com/OAI/OpenAPI-Specification/assets/7367/7e43dbbb-6529-46e6-8b04-4c1aa852d9dd"> | <img width="323" alt="Screenshot of Zoom UI showing the 'Reaction' and 'Raise Hand' control" src="https://github.com/OAI/OpenAPI-Specification/assets/7367/f991722f-4651-40aa-9bc4-7e9a2a165a6a"> |
+
+### Agenda Structure
+
+| Topic | Owner | Decision/NextStep |
+|-|-|-|
+Intros and governance meta-topics (5 mins) | TDC | |
+Reports from Special Interest Groups (5 mins) | SIG members | |
+Any other business (add comments below to suggest topics) | TDC | |
+[Approved spec PRs](https://github.com/OAI/Arazzo-Specification/pulls?q=is%3Apr+is%3Aopen+review%3Aapproved) | @OAI/tsc | |
+[Active Projects](https://github.com/OAI/Arazzo-Specification/projects?query=is%3Aopen) | @OAI/openapi-maintainers | |
+[New issues needing attention](https://github.com/search?q=repo%3Aoai%2Farazzo-specification+is%3Aissue+comments%3A0+no%3Alabel+is%3Aopen) | @OAI/triage  | |
+
+/cc [@OAI/tsc](https://github.com/orgs/OAI/teams/tsc) please suggest items for inclusion.

--- a/.github/templates/agenda.md
+++ b/.github/templates/agenda.md
@@ -7,7 +7,7 @@ Whether attending or not, **anyone can comment on this issue prior to the meetin
 Meetings take place over Zoom: [https://zoom.us/j/91426197903](https://zoom.us/j/91426197903?pwd=cjNGcjgzWmRqZ1YyRW9PM3FFNFVFUT09), dial-in passcode: 763054
 
 ### Accessibility & Etiquette
-* Participants must abide by our [Code-of-Conduct](https://github.com/OAI/OpenAPI-Specification/blob/main/CODE_OF_CONDUCT.md#code-of-conduct).
+* Participants must abide by our [Code-of-Conduct](https://github.com/OAI/Arazzo-Specification?tab=coc-ov-file#code-of-conduct).
 
 
 * We invite you to feel comfortable to challenge any language or behaviour that is harmful or not inclusive during this meeting.

--- a/.github/templates/agenda.md
+++ b/.github/templates/agenda.md
@@ -1,4 +1,4 @@
-## Weekly meetings happen on Thursdays at 9am - 10am Pacific
+## Bi-Weekly meetings happen on Wednesdays at 5PM GMT
 
 This agenda gives visibility into discussion topics for the weekly Technical Developer Community (TDC) meetings. Sharing agenda items in advance allows people to plan to attend meetings where they have an interest in specific topics. 
 


### PR DESCRIPTION
per issue #263 , adding template for arazzo meetings with code of conduct.

Changed Zoom url to match existing url

Also changed issue links to match arazzo links.