### PR TITLE
Fix reference to the CoC

### DIFF
--- a/.github/ISSUE_TEMPLATE/use-case-template.yml
+++ b/.github/ISSUE_TEMPLATE/use-case-template.yml
@@ -47,7 +47,7 @@ body:
     id: terms
     attributes:
       label: Code of Conduct
-      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/OAI/OpenAPI-Specification/blob/main/CODE_OF_CONDUCT.md)
+      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/OAI/Arazzo-Specification?tab=coc-ov-file#code-of-conduct)
       options:
         - label: I agree to follow this project's Code of Conduct
           required: true


### PR DESCRIPTION
Because the OAI has an org-level code of conduct, this repo picks that up by default. IIUC, is preferable to refer to this using the project's instantiation of that document.