### PR TITLE
respec build script: create minor-version symlinks

### DIFF
--- a/scripts/md2html/build.sh
+++ b/scripts/md2html/build.sh
@@ -17,18 +17,28 @@ cp -p ../../node_modules/respec/builds/respec-w3c.* ../../deploy/js/
 # latest=`git describe --abbrev=0 --tags` -- introduce after release tags created
 latest=1.0.0
 latestCopied=none
-for filename in ../../versions/[123456789].*.md ; do
+lastMinor="-"
+for filename in $(ls -1 ../../versions/[123456789].*.md | sort -r) ; do
   version=$(basename "$filename" .md)
+  minorVersion=${version:0:3}
   tempfile=../../deploy/arazzo/v$version-tmp.html
+  echo -e "\n=== v$version ==="
+
   node md2html.js --respec --maintainers ../../MAINTAINERS.md ${filename} > $tempfile
   npx respec --use-local --src $tempfile --out ../../deploy/arazzo/v$version.html
   rm $tempfile
+
   if [ $version = $latest ]; then
     if [[ ${version} != *"rc"* ]];then
       # version is not a Release Candidate
-      cp -p ../../deploy/arazzo/v$version.html ../../deploy/arazzo/latest.html
+      ( cd ../../deploy/arazzo && ln -sf v$version.html latest.html )
       latestCopied=v$version
     fi
+  fi
+
+  if [ ${minorVersion} != ${lastMinor} ]; then
+    ( cd ../../deploy/arazzo && ln -sf v$version.html v$minorVersion.html )
+    lastMinor=$minorVersion
   fi
 done
 echo Latest tag is $latest, copied $latestCopied to latest.html


### PR DESCRIPTION
The minor-version symlink points to the latest published patch version and allows linking to the minor version, for example from the patch-version-independent JSON schema for Arazzo descriptions.
