### PR TITLE
Clarify origin or runtime expressions ABNF non-terminals

### DIFF
--- a/src/arazzo.md
+++ b/src/arazzo.md
@@ -845,6 +845,10 @@ The runtime expression is defined by the following [ABNF](https://tools.ietf.org
         "^" / "_" / "`" / "|" / "~" / DIGIT / ALPHA
 ```
 
+Here, `json-pointer` is taken from [RFC6901](https://tools.ietf.org/html/rfc6901), `CHAR` from [RFC7159](https://tools.ietf.org/html/rfc7159#section-7) and `token` from [RFC7230](https://tools.ietf.org/html/rfc7230#section-3.2.6).
+
+The `name` identifier is case-sensitive, whereas `token` is not.
+
 #### Examples
 
 Source Location | example expression  | notes


### PR DESCRIPTION
This change will also allow to normalize `token` during the parsing.

Closes #253