### PR TITLE
refactor(arazzo): remove brackets around condition

### DIFF
--- a/src/arazzo.md
+++ b/src/arazzo.md
@@ -571,7 +571,7 @@ components:
       "workflowId": "refreshTokenWorkflowId",
       "criteria": [
         {
-          "condition": "{$statusCode == 401}"
+          "condition": "$statusCode == 401"
         }
       ]
     }


### PR DESCRIPTION
The example indicates that when YAML format is translated to JSON, the brackets SHOULD be added to the condition.