### PR TITLE
chore(workflows): add branch sync actions and update to client-id token

### DIFF
--- a/.github/workflows/schema-publish.yaml
+++ b/.github/workflows/schema-publish.yaml
@@ -26,7 +26,7 @@ jobs:
         id: generate-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.OAI_SPEC_PUBLISHER_APPID }}
+          client-id: ${{ secrets.OAI_SPEC_PUBLISHER_APPID }}
           private-key: ${{ secrets.OAI_SPEC_PUBLISHER_PRIVATE_KEY }}
           owner: OAI
           repositories: spec.openapis.org

--- a/.github/workflows/sync-dev-to-vX.Y-dev.yaml
+++ b/.github/workflows/sync-dev-to-vX.Y-dev.yaml
@@ -1,0 +1,73 @@
+name: sync-dev-to-vX.Y-dev
+
+# author: @ralfhandl
+
+#
+# This workflow creates PRs to update the vX.Y-dev branch with the latest changes from dev
+#
+
+# run this on push to dev
+on:
+  push:
+    branches:
+      - dev
+  workflow_dispatch: {}
+
+jobs:
+  sync-branches:
+    if: github.repository == 'OAI/Arazzo-Specification'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate access token
+        id: generate-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ secrets.OAI_SPEC_PUBLISHER_APPID }}
+          private-key: ${{ secrets.OAI_SPEC_PUBLISHER_PRIVATE_KEY }}
+
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          token: ${{ steps.generate-token.outputs.token }}
+
+      - name: Create pull requests
+        id: pull_requests
+        shell: bash
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          DEV_BRANCHES=$(git branch -r --list origin/v?.?-dev)
+          for DEV_BRANCH in $DEV_BRANCHES; do
+            BASE=${DEV_BRANCH:7}
+            SYNC="$BASE-sync-with-$HEAD"
+
+            git checkout -b $SYNC origin/$SYNC || git checkout -b $SYNC origin/$BASE
+            git merge origin/$HEAD -m "Merge $HEAD into $SYNC"
+            git checkout origin/$BASE src/
+            git checkout origin/$BASE tests/schema/
+            git commit -m "Restored src/ and tests/schema/" || echo ""
+            git push -u origin $SYNC
+
+            EXISTS=$(gh pr list --base $BASE --head $SYNC \
+              --json number --jq '.[] | .number')
+            if [ ! -z "$EXISTS" ]; then
+              echo "PR #$EXISTS already wants to merge $SYNC into $BASE"
+              continue
+            fi
+
+            PR=$(gh pr create --base $BASE --head $SYNC \
+              --label "Housekeeping" \
+              --title "$BASE: sync with $HEAD" \
+              --body "Merge relevant changes from \`$HEAD\` into \`$BASE\`.")
+            echo ""
+            echo "PR to sync $BASE with $HEAD: $PR"
+            sleep 60 # allow status checks to be triggered
+
+            gh pr checks $PR --watch --required || continue
+            gh pr merge $PR --merge --admin
+          done
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+          HEAD: dev

--- a/.github/workflows/sync-main-to-dev.yaml
+++ b/.github/workflows/sync-main-to-dev.yaml
@@ -1,0 +1,63 @@
+name: sync-main-to-dev
+
+# author: @ralfhandl
+
+#
+# This workflow creates PRs to update the dev branch with the latest changes from main
+#
+
+# run this on push to main
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch: {}
+
+jobs:
+  sync-branch:
+    if: github.repository == 'OAI/Arazzo-Specification'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate access token
+        id: generate-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ secrets.OAI_SPEC_PUBLISHER_APPID }}
+          private-key: ${{ secrets.OAI_SPEC_PUBLISHER_PRIVATE_KEY }}
+
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          token: ${{ steps.generate-token.outputs.token }}
+
+      - name: Create pull request
+        id: pull_request
+        shell: bash
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          SYNC="$BASE-sync-with-$HEAD"
+
+          git checkout -b $SYNC origin/$SYNC || git checkout -b $SYNC origin/$BASE
+          git merge origin/$HEAD -m "Merge $HEAD into $SYNC"
+          git checkout origin/$BASE src/
+          git checkout origin/$BASE tests/schema/
+          git commit -m "Restored src/ and tests/schema/" || echo ""
+          git push -u origin $SYNC
+
+          EXISTS=$(gh pr list --base $BASE --head $SYNC \
+            --json number --jq '.[] | .number')
+          if [ ! -z "$EXISTS" ]; then
+            echo "PR #$EXISTS already wants to merge $SYNC into $BASE"
+            exit 0
+          fi
+
+          gh pr create --base $BASE --head $SYNC \
+            --label "Housekeeping" \
+            --title "$BASE: sync with $HEAD" \
+            --body "Merge relevant changes from \`$HEAD\` into \`$BASE\`."
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+          HEAD: main
+          BASE: dev


### PR DESCRIPTION
closes #397

Adds two GitHub Actions workflows to automate housekeeping sync between branches:

- `sync-main-to-dev.yaml` — triggers on push to `main`, creates a PR to merge relevant changes into `dev`, restoring `src/` and `tests/schema/` to preserve spec and test content
- `sync-dev-to-vX.Y-dev.yaml` — triggers on push to `dev`, creates PRs to merge relevant changes into all active `vX.Y-dev` branches, with the same `src/` and `tests/schema/` restoration, and auto-merges after required checks pass

Also updates `schema-publish.yaml` to use the `client-id` parameter (replacing the deprecated `app-id`) for `actions/create-github-app-token@v3`, consistent with the approach used in the OpenAPI-Specification repo.