### PR TITLE
fix(spec): specify ECMA-262 dialect for regex Criterion condition type

### DIFF
--- a/src/arazzo.md
+++ b/src/arazzo.md
@@ -838,7 +838,7 @@ An object used to specify the context, conditions, and condition types that can 
 There are four flavors of conditions supported:
 
 - simple - where basic literals, operators, and loose comparisons are used in combination with [Runtime Expressions](#runtime-expressions).
-- regex - where a regex pattern is applied on the supplied context. The context is defined by a [Runtime Expression](#runtime-expressions).
+- regex - where a regex pattern is applied on the supplied context. The pattern MUST be a valid regular expression according to the [ECMA-262](https://tc39.es/ecma262/#sec-patterns) regular expression dialect. The context is defined by a [Runtime Expression](#runtime-expressions).
 - jsonpath - where a JSONPath expression is applied. The root node context is defined by a [Runtime Expression](#runtime-expressions).
 - xpath - where an XPath expression is applied. The root node context is defined by a [Runtime Expression](#runtime-expressions).
 
@@ -954,7 +954,7 @@ Example:
 
 ###### Regex Conditions
 
-When `type` is `regex`, the `condition` MUST be a valid regular expression pattern, and `context` MUST be provided. The condition evaluates to:
+When `type` is `regex`, the `condition` MUST be a valid regular expression according to the [ECMA-262](https://tc39.es/ecma262/#sec-patterns) regular expression dialect, and `context` MUST be provided. The condition evaluates to:
 
 - A condition passes (truthy) when the regex pattern matches the `context` value.
 - A condition fails (falsy) when the regex pattern does not match the `context` value.


### PR DESCRIPTION
Closes #515

## Summary

The Criterion Object's `regex` condition type did not name a regular-expression dialect, while the sibling `jsonpath` (RFC 9535) and `xpath` (XML Path Language 3.1) types both pin a standard. This left regex matching non-portable across Arazzo runners: dialects differ in lookbehind `(?<=…)`, named groups, backreferences, and Unicode property escapes `\p{…}`, so a condition such as `(?<=x)y` or `\p{L}+` could pass on one runtime and fail (or error) on another.

This PR pins **ECMA-262** for the `regex` type, matching OpenAPI / JSON Schema Validation (the sibling specification under the OAI, which pins ECMA-262 for `pattern`/`patternProperties`) and what the most common runners implement via native regex engines.

## Changes

Two clarifying edits to `src/arazzo.md`, both linking to the [ECMA-262 patterns grammar](https://tc39.es/ecma262/#sec-patterns):

- Criterion Object condition flavors list — the `regex` entry now states the pattern MUST be a valid regular expression according to the ECMA-262 dialect.
- Regex Conditions evaluation section — the `condition` MUST be a valid ECMA-262 regular expression.

This is a clarification that does not change the intended meaning of the specification, so it targets `v1.1-dev` per the [branching strategy](https://github.com/OAI/Arazzo-Specification/blob/main/CONTRIBUTING.md#branching-strategy) (apply to the earliest relevant active branch). `markdownlint` passes.